### PR TITLE
[TEST-RUNNER]: Use cobolcheck from $PATH if available

### DIFF
--- a/exercises/practice/bob/test.sh
+++ b/exercises/practice/bob/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/collatz-conjecture/test.sh
+++ b/exercises/practice/collatz-conjecture/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/difference-of-squares/test.sh
+++ b/exercises/practice/difference-of-squares/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/hamming/test.sh
+++ b/exercises/practice/hamming/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/hello-world/test.sh
+++ b/exercises/practice/hello-world/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/isogram/test.sh
+++ b/exercises/practice/isogram/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/leap/test.sh
+++ b/exercises/practice/leap/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/pangram/test.sh
+++ b/exercises/practice/pangram/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/reverse-string/test.sh
+++ b/exercises/practice/reverse-string/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/rna-transcription/test.sh
+++ b/exercises/practice/rna-transcription/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/rotational-cipher/test.sh
+++ b/exercises/practice/rotational-cipher/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/two-fer/test.sh
+++ b/exercises/practice/two-fer/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob

--- a/exercises/practice/yacht/test.sh
+++ b/exercises/practice/yacht/test.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
 SLUG=$(basename "${SCRIPT_DIR}")
+COBOLCHECK=./bin/cobolcheck
 
-if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
+WHICH_COBOLCHECK=$(which cobolcheck)
+if [[ $? -eq 0 ]] ; then
+    echo "Found cobolcheck, using $COBOLCHECK"
+    COBOLCHECK=$WHICH_COBOLCHECK
+elif [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
     cd $SCRIPT_DIR/bin/
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p $SLUG
+$COBOLCHECK -p $SLUG
 
 # compile and run
+echo "COMPILE AND RUN TEST"
 cobc -xj test.cob


### PR DESCRIPTION
In order to save time and bandwidth cobolcheck is not downloaded if already installed on the machine

Signed-off-by: Sven Pfennig <s.pfennig@reply.de>